### PR TITLE
added indent-blankline

### DIFF
--- a/lua/plugins/indent-blankline.lua
+++ b/lua/plugins/indent-blankline.lua
@@ -1,0 +1,7 @@
+return {
+	'lukas-reineke/indent-blankline.nvim',
+	opts = {
+		char = '┊',
+		show_trailing_blankline_indent = false,
+	}
+}


### PR DESCRIPTION
[indent-blankline](https://github.com/lukas-reineke/indent-blankline.nvim): Indent guides for Neovim

This plugin adds indentation guides to all lines (including empty lines).

It uses Neovim's virtual text feature and no conceal

This plugin requires Neovim 0.5 or higher. It makes use of Neovim only features so it will not work in Vim. There is a legacy version of the plugin that supports Neovim 0.4 under the branch version-1

