### PR TITLE
onedark

### DIFF
--- a/lua/plugins/nordic.lua
+++ b/lua/plugins/nordic.lua
@@ -1,8 +1,0 @@
-return {
-	'AlexvZyl/nordic.nvim',
-	lazy = false,
-	priority = 1000,
-	config = function()
-		require('nordic').load()
-	end
-}

--- a/lua/plugins/onedark.lua
+++ b/lua/plugins/onedark.lua
@@ -1,0 +1,11 @@
+return {
+	'navarasu/onedark.nvim',
+	priority = 1000,
+	config = function()
+		local onedark = require('onedark')
+		onedark.setup({
+			style = 'darker'
+		})
+		onedark.load()
+	end
+}


### PR DESCRIPTION
[onedark](https://github.com/navarasu/onedark.nvim): One dark and light colorscheme for neovim >= 0.5.0 written in lua based on Atom's One Dark and Light theme. Additionally, it comes with 5 color variant styles

